### PR TITLE
Add parsing of until_date argument and meduza and ria spiders until_date

### DIFF
--- a/scrapping/newsbot/newsbot/pipelines.py
+++ b/scrapping/newsbot/newsbot/pipelines.py
@@ -13,15 +13,20 @@ class NewsbotPipeline(object):
         self.file.close()
 
     def process_item(self, item, spider):
+        dt = datetime.datetime.strptime(item["date"][0], spider.config.date_format)
+
         item["title"] = spider.process_title(item["title"][0])
         item["topics"] = item["topics"][0]
         item["edition"] = item["edition"][0]
         item["url"] = item["url"][0]
         item["text"] = spider.process_text(item["text"])
-        date = datetime.datetime.strptime(item["date"][0], spider.config.date_format)
-        item["date"] = date.strftime("%Y-%m-%d %H:%M:%S")
-        line = (item["date"], item["url"], item["edition"], '"' + item["topics"] + '"',
-            '"' + item["title"] + '"', '"' + item["text"] + '"' + '\n')
-        line = ",".join(line)
-        self.file.write(line)
+        item["date"] = dt.strftime("%Y-%m-%d %H:%M:%S")
+
+        # Filtering out too late items
+        if dt.date() >= spider.until_date:
+            line = (item["date"], item["url"], item["edition"], '"' + item["topics"] + '"',
+                    '"' + item["title"] + '"', '"' + item["text"] + '"' + '\n')
+            line = ",".join(line)
+            self.file.write(line)
+
         return item

--- a/scrapping/newsbot/newsbot/spiders/news.py
+++ b/scrapping/newsbot/newsbot/spiders/news.py
@@ -1,4 +1,5 @@
 from urllib.parse import urlsplit
+from datetime import datetime, timedelta
 
 import scrapy
 from scrapy.loader import ItemLoader
@@ -23,6 +24,14 @@ class NewsSpider(scrapy.Spider):
         assert self.config.date_format
         assert self.config.text_path
         assert self.config.topics_path
+
+        # Trying to parse 'until_date' param as date
+        if 'until_date' in kwargs:
+            kwargs['until_date'] = datetime.strptime(kwargs['until_date'], '%d.%m.%Y').date()
+        else:
+            # If there's no 'until_date' param, get articles for today and yesterday
+            kwargs['until_date'] = (datetime.now() - timedelta(days=1)).date()
+
         super().__init__(*args, **kwargs)
 
     def parse_document(self, response):


### PR DESCRIPTION
1) В spiders/news.py добавил передачу аргумента "until_date" (если он не указан, то считается равным вчерашнему дню)
Пример вызова:
`scrapy crawl ria -a until_date=24.02.2019`

2) Исправил логику spiders/meduza.py и spiders/ria.py - теперь они выбирают новости глубиной до until_date включительно

3) Поправил pipelines.py, чтобы сохранялись в файл только те статьи, дата публикации которых не меньше "until_date" (так как на последней выбранной нами странице новостей могли быть новости старее "until_date")