### PR TITLE
Add metrics gathering to pipeline

### DIFF
--- a/scraping/newsbot/.gitignore
+++ b/scraping/newsbot/.gitignore
@@ -37,3 +37,4 @@ media/
 *.jl.gz
 .releases
 
+*.log

--- a/scraping/newsbot/newsbot/items.py
+++ b/scraping/newsbot/newsbot/items.py
@@ -14,4 +14,14 @@ class Document(scrapy.Item):
     edition = scrapy.Field()
     topics = scrapy.Field()
     authors = scrapy.Field()
+    reposts_fb = scrapy.Field()
+    reposts_vk = scrapy.Field()
+    reposts_ok = scrapy.Field()
+    reposts_twi = scrapy.Field()
+    reposts_lj = scrapy.Field()
+    reposts_tg = scrapy.Field()
+    likes = scrapy.Field()
+    views = scrapy.Field()
+    comm_count = scrapy.Field()
+
 

--- a/scraping/newsbot/newsbot/pipelines.py
+++ b/scraping/newsbot/newsbot/pipelines.py
@@ -5,9 +5,16 @@
 
 import datetime
 
+
 class NewsbotPipeline(object):
     def open_spider(self, spider):
         self.file = open(spider.name + '.csv', 'w')
+
+        # Write header to the resulting file
+        self._fields = ["date", "url", "edition", "topics", "authors", "title", "text"]
+        self._metrics = ["reposts_fb", "reposts_vk", "reposts_ok", "reposts_twi",
+                         "reposts_lj", "reposts_tg", "likes", "views", "comm_count"]
+        self.file.write(','.join(self._fields + self._metrics) + '\n')
 
     def close_spider(self, spider):
         self.file.close()
@@ -23,11 +30,35 @@ class NewsbotPipeline(object):
         item["text"] = spider.process_text(item["text"])
         item["date"] = dt.strftime("%Y-%m-%d %H:%M:%S")
 
+        item = self._process_metrics(spider, item, self._metrics)
+
         # Filtering out too late items
         if dt.date() >= spider.until_date:
             line = (item["date"], item["url"], item["edition"], '"' + item["topics"] + '"',
-                    '"' + item["authors"] + '"', '"' + item["title"] + '"', '"' + item["text"] + '"' + '\n')
+                    '"' + item["authors"] + '"',
+                    '"' + item["title"] + '"',
+                    '"' + item["text"] + '"',
+                    item["reposts_fb"],
+                    item["reposts_vk"],
+                    item["reposts_ok"],
+                    item["reposts_twi"],
+                    item["reposts_lj"],
+                    item["reposts_tg"],
+                    item["likes"],
+                    item["views"],
+                    item["comm_count"],
+                    '\n')
             line = ",".join(line)
             self.file.write(line)
 
         return item
+
+    def _process_metrics(self, spider, item, metrics):
+        for m in metrics:
+            if spider.config.__getattribute__(m + '_path') == "_":
+                item[m] = "-"
+            else:
+                item[m] = spider.process_metric(item.get(m, ['0']))
+
+        return item
+

--- a/scraping/newsbot/newsbot/spiders/gazeta.py
+++ b/scraping/newsbot/newsbot/spiders/gazeta.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from scrapy.linkextractors import LinkExtractor
 from scrapy import Request, Selector
 
 from newsbot.spiders.news import NewsSpider, NewsSpiderConfig
@@ -18,11 +17,17 @@ class GazetaSpider(NewsSpider):
         text_path='//div[contains(@itemprop, "articleBody")]//p//text() | '
                   '//span[contains(@itemprop, "description")]//text()',
         topics_path='//div[contains(@class, "active")]/a/span/text()',
-        authors_path='//span[contains(@itemprop, "author")]//text()'
+        authors_path='//span[contains(@itemprop, "author")]//text()',
+        reposts_fb_path='_',
+        reposts_vk_path='_',
+        reposts_ok_path='_',
+        reposts_twi_path='_',
+        reposts_lj_path='_',
+        reposts_tg_path='_',
+        likes_path='_',
+        views_path='_',
+        comm_count_path='_'
     )
-    sitemap_le = LinkExtractor(restrict_xpaths='//div[contains(@class, "sitemap_list")]/ul/ul')
-    articles_le = LinkExtractor(restrict_xpaths='//h2[contains(@itemprop, "headline")]')
-    news_le = LinkExtractor(restrict_css='div.article_text h1.txt_2b')
 
     def parse(self, response):
         # Parse main sitemap

--- a/scraping/newsbot/newsbot/spiders/interfax.py
+++ b/scraping/newsbot/newsbot/spiders/interfax.py
@@ -14,7 +14,16 @@ class InterfaxSpider(NewsSpider):
         date_format="%Y-%m-%dT%H:%M:%S",
         text_path='//article//text()',
         topics_path='//div[contains(@class, "textML")]/a/text()',
-        authors_path='_'
+        authors_path='_',
+        reposts_fb_path='_',
+        reposts_vk_path='_',
+        reposts_ok_path='_',
+        reposts_twi_path='_',
+        reposts_lj_path='_',
+        reposts_tg_path='_',
+        likes_path='_',
+        views_path='_',
+        comm_count_path='_'
     )
 
     def parse(self, response):

--- a/scraping/newsbot/newsbot/spiders/iz.py
+++ b/scraping/newsbot/newsbot/spiders/iz.py
@@ -15,7 +15,16 @@ class IzSpider(NewsSpider):
         date_format="%Y-%m-%dT%H:%M:%SZ",
         text_path='//div[contains(@itemprop, "articleBody")]/div/p//text()',
         topics_path='//div[contains(@class, "rubrics_btn")]/div/a/text()',
-        authors_path='_'
+        authors_path='_',
+        reposts_fb_path='//li[contains(@class, "item_service_facebook")]//text()',
+        reposts_vk_path='//li[contains(@class, "item_service_vkontakte")]//text()',
+        reposts_ok_path='//li[contains(@class, "item_service_odnoklassniki")]//text()',
+        reposts_twi_path='//li[contains(@class, "item_service_twitter")]//text()',
+        reposts_lj_path='_',
+        reposts_tg_path='_',
+        likes_path='_',
+        views_path='//div[contains(@id, "viewsCounter")]//text()',
+        comm_count_path='_'
     )
       
     visited_urls = []

--- a/scraping/newsbot/newsbot/spiders/kommersant.py
+++ b/scraping/newsbot/newsbot/spiders/kommersant.py
@@ -26,7 +26,16 @@ class KommersantSpider(NewsSpider):
         date_format='%Y-%m-%dT%H:%M:%S%z',  # 2019-03-09T12:03:10+03:00
         text_path='//p[@class="b-article__text"]//text()',
         topics_path='//meta[contains(@name, "category")]/@content',
-        authors_path='//p[contains(@class, "document_authors")]//text()'
+        authors_path='//p[contains(@class, "document_authors")]//text()',
+        reposts_fb_path='_',
+        reposts_vk_path='_',
+        reposts_ok_path='_',
+        reposts_twi_path='_',
+        reposts_lj_path='_',
+        reposts_tg_path='_',
+        likes_path='_',
+        views_path='_',
+        comm_count_path='_'
     )
     news_le = LinkExtractor(restrict_xpaths='//div[@class="archive_result__item_text"]')
 

--- a/scraping/newsbot/newsbot/spiders/meduza.py
+++ b/scraping/newsbot/newsbot/spiders/meduza.py
@@ -24,7 +24,16 @@ class MeduzaSpider(NewsSpider):
         date_format='%Y-%m-%d %H:%M:%S',
         text_path='_',
         topics_path='_',
-        authors_path='_'
+        authors_path='_',
+        reposts_fb_path='_',
+        reposts_vk_path='_',
+        reposts_ok_path='_',
+        reposts_twi_path='_',
+        reposts_lj_path='_',
+        reposts_tg_path='_',
+        likes_path='_',
+        views_path='_',
+        comm_count_path='_'
     )
 
     def parse(self, response):

--- a/scraping/newsbot/newsbot/spiders/news.py
+++ b/scraping/newsbot/newsbot/spiders/news.py
@@ -8,13 +8,25 @@ from newsbot.items import Document
 
 
 class NewsSpiderConfig:
-    def __init__(self, title_path, date_path, date_format, text_path, topics_path, authors_path):
+    def __init__(self, title_path, date_path, date_format, text_path, topics_path, authors_path,
+                 reposts_fb_path, reposts_vk_path, reposts_ok_path, reposts_twi_path, reposts_lj_path,
+                 reposts_tg_path, likes_path, views_path, comm_count_path):
         self.title_path = title_path
         self.date_path = date_path
         self.date_format = date_format
         self.text_path = text_path
         self.topics_path = topics_path
         self.authors_path = authors_path
+
+        self.reposts_fb_path = reposts_fb_path
+        self.reposts_vk_path = reposts_vk_path
+        self.reposts_ok_path = reposts_ok_path
+        self.reposts_twi_path = reposts_twi_path
+        self.reposts_lj_path = reposts_lj_path
+        self.reposts_tg_path = reposts_tg_path
+        self.likes_path = likes_path
+        self.views_path = views_path
+        self.comm_count_path = comm_count_path
 
 
 class NewsSpider(scrapy.Spider):
@@ -26,6 +38,16 @@ class NewsSpider(scrapy.Spider):
         assert self.config.text_path
         assert self.config.topics_path
         assert self.config.authors_path
+
+        assert self.config.reposts_fb_path
+        assert self.config.reposts_vk_path
+        assert self.config.reposts_ok_path
+        assert self.config.reposts_twi_path
+        assert self.config.reposts_lj_path
+        assert self.config.reposts_tg_path
+        assert self.config.likes_path
+        assert self.config.views_path
+        assert self.config.comm_count_path
 
         # Trying to parse 'until_date' param as date
         if 'until_date' in kwargs:
@@ -49,6 +71,17 @@ class NewsSpider(scrapy.Spider):
         l.add_xpath('text', self.config.text_path)
         l.add_xpath('topics', self.config.topics_path)
         l.add_xpath('authors', self.config.authors_path)
+
+        l.add_xpath('reposts_fb', self.config.reposts_fb_path)
+        l.add_xpath('reposts_vk', self.config.reposts_vk_path)
+        l.add_xpath('reposts_ok', self.config.reposts_ok_path)
+        l.add_xpath('reposts_twi', self.config.reposts_twi_path)
+        l.add_xpath('reposts_lj', self.config.reposts_lj_path)
+        l.add_xpath('reposts_tg', self.config.reposts_tg_path)
+        l.add_xpath('likes', self.config.likes_path)
+        l.add_xpath('views', self.config.views_path)
+        l.add_xpath('comm_count', self.config.comm_count_path)
+
         yield l.load_item()
 
     def process_title(self, title):
@@ -59,4 +92,9 @@ class NewsSpider(scrapy.Spider):
         text = "\\n".join([p.strip() for p in paragraphs if p.strip()])
         text = text.replace('"', '\\"')
         return text
+
+    def process_metric(self, metrics):
+        # Remove whitespaces
+        metrics = [i.strip() for i in metrics if i.strip()]
+        return metrics[0]
 

--- a/scraping/newsbot/newsbot/spiders/rbc.py
+++ b/scraping/newsbot/newsbot/spiders/rbc.py
@@ -19,7 +19,16 @@ class RbcSpider(NewsSpider):
         text_path='(.//div[contains(@class, "article__text")])'
                   '/*[not(self::script) and not(self::div[@class="subscribe-infographic"])]//text()',
         topics_path='(.//a[contains(@class, "article__header__category")])[1]//text()',
-        authors_path='//div[contains(@class, "article__authors")]/text()'
+        authors_path='//div[contains(@class, "article__authors")]/text()',
+        reposts_fb_path='_',
+        reposts_vk_path='_',
+        reposts_ok_path='_',
+        reposts_twi_path='_',
+        reposts_lj_path='_',
+        reposts_tg_path='_',
+        likes_path='_',
+        views_path='_',
+        comm_count_path='_'
     )
 
     def parse(self, response):

--- a/scraping/newsbot/newsbot/spiders/ria.py
+++ b/scraping/newsbot/newsbot/spiders/ria.py
@@ -17,7 +17,16 @@ class RiaSpider(NewsSpider):
         date_format='%Y-%m-%dT%H:%MZ',
         text_path='//div[contains(@class, "article__block") and @data-type = "text"]//text()',
         topics_path='//a[contains(@class, "article__tags-item")]/text()',
-        authors_path='_'
+        authors_path='_',
+        reposts_fb_path='_',
+        reposts_vk_path='_',
+        reposts_ok_path='_',
+        reposts_twi_path='_',
+        reposts_lj_path='_',
+        reposts_tg_path='_',
+        likes_path='_',
+        views_path='_',
+        comm_count_path='_'
     )
     news_le = LinkExtractor(restrict_css='div.lenta__item')
 

--- a/scraping/newsbot/newsbot/spiders/rt.py
+++ b/scraping/newsbot/newsbot/spiders/rt.py
@@ -16,9 +16,17 @@ class RussiaTodaySpider(NewsSpider):
         '[contains(@name, "mediator_published_time")]/@content',
         date_format="%Y-%m-%dT%H:%M:%S",
         text_path='//div[contains(@class, "article__text")]//text()',
-        topics_path='//meta'
-        '[contains(@name, "mediator_theme")]/@content',
-        authors_path='_'
+        topics_path='//meta[contains(@name, "mediator_theme")]/@content',
+        authors_path='_',
+        reposts_fb_path='_',
+        reposts_vk_path='_',
+        reposts_ok_path='_',
+        reposts_twi_path='_',
+        reposts_lj_path='_',
+        reposts_tg_path='_',
+        likes_path='_',
+        views_path='_',
+        comm_count_path='_'
     )
 
     def parse(self, response):

--- a/scraping/newsbot/newsbot/spiders/tass.py
+++ b/scraping/newsbot/newsbot/spiders/tass.py
@@ -20,7 +20,16 @@ class RussiaTassSpider(NewsSpider):
         date_format="%Y-%m-%d %H:%M:%S",
         text_path="div.text-content>div.text-block ::text",
         topics_path='_',
-        authors_path='_'
+        authors_path='_',
+        reposts_fb_path='_',
+        reposts_vk_path='_',
+        reposts_ok_path='_',
+        reposts_twi_path='_',
+        reposts_lj_path='_',
+        reposts_tg_path='_',
+        likes_path='_',
+        views_path='_',
+        comm_count_path='_'
     )
     custom_settings = {
         "DEPTH_LIMIT": 4,

--- a/scraping/newsbot/newsbot/spiders/tvzvezda.py
+++ b/scraping/newsbot/newsbot/spiders/tvzvezda.py
@@ -11,7 +11,16 @@ class TvZvezdaSpider(NewsSpider):
         date_format="%H:%M %d.%m.%Y",
         text_path='//div[contains(@class, "glav_text")]//text()',
         topics_path='//meta[contains(@property, "article:section")]/@content',
-        authors_path='//div[contains(@class, "autor_news")]/a/text()'
+        authors_path='//div[contains(@class, "autor_news")]/a/text()',
+        reposts_fb_path='_',
+        reposts_vk_path='_',
+        reposts_ok_path='_',
+        reposts_twi_path='_',
+        reposts_lj_path='_',
+        reposts_tg_path='_',
+        likes_path='_',
+        views_path='_',
+        comm_count_path='_'
     )
     news_le = LinkExtractor(restrict_css='div.js-ajax-receiver a.news_one')
 

--- a/scraping/newsbot/newsbot/spiders/vedomosti.py
+++ b/scraping/newsbot/newsbot/spiders/vedomosti.py
@@ -17,7 +17,16 @@ class VedomostiSpider(NewsSpider):
         date_format='%Y-%m-%d %H:%M:%S %z',  # 2019-03-02 20:08:47 +0300
         text_path='(.//div[contains(@class, "b-news-item__text")])[1]/p//text()',
         topics_path='(.//div[contains(@class, "io-category")])[1]/text()',
-        authors_path='_'
+        authors_path='_',
+        reposts_fb_path='_',
+        reposts_vk_path='_',
+        reposts_ok_path='_',
+        reposts_twi_path='_',
+        reposts_lj_path='_',
+        reposts_tg_path='_',
+        likes_path='_',
+        views_path='_',
+        comm_count_path='_'
     )
     news_le = LinkExtractor(restrict_xpaths='//div[contains(@class, "b-newsline-item__title")]')
 


### PR DESCRIPTION
Adds to pipeline ability to gather metrics of news/articles.

**Metrics:** 
reposts (Facebook, VKontakte, Odnoklassniki, Twitter, Lifejournal, Telegram)
likes
views
comments

**If '_' is set as a path to the metric** (in `NewsSpiderConfig`), then '-' is written to the result file (signalling that there's no such metric for this particular website)

However **if '_' is set as a path to the metric** (in `NewsSpiderConfig`), then '0' will be written to the result file (in case nothing was found on the page for specified path)